### PR TITLE
USB: Change BUFF_STATUS access to read-write

### DIFF
--- a/src/usbctrl_regs.rs
+++ b/src/usbctrl_regs.rs
@@ -317,13 +317,15 @@ impl crate::Readable for INT_EP_CTRL {}
 impl crate::Writable for INT_EP_CTRL {}
 #[doc = "interrupt endpoint control register"]
 pub mod int_ep_ctrl;
-#[doc = "Buffer status register. A bit set here indicates that a buffer has completed on the endpoint (if the buffer interrupt is enabled). It is possible for 2 buffers to be completed, so clearing the buffer status bit may instantly re set it on the next clock cycle.\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [buff_status](buff_status) module"]
+#[doc = "Buffer status register. A bit set here indicates that a buffer has completed on the endpoint (if the buffer interrupt is enabled). It is possible for 2 buffers to be completed, so clearing the buffer status bit may instantly re set it on the next clock cycle.\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [buff_status](buff_status) module"]
 pub type BUFF_STATUS = crate::Reg<u32, _BUFF_STATUS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
 pub struct _BUFF_STATUS;
 #[doc = "`read()` method returns [buff_status::R](buff_status::R) reader structure"]
 impl crate::Readable for BUFF_STATUS {}
+#[doc = "`write(|w| ..)` method takes [buff_status::W](buff_status::W) writer structure"]
+impl crate::Writable for BUFF_STATUS {}
 #[doc = "Buffer status register. A bit set here indicates that a buffer has completed on the endpoint (if the buffer interrupt is enabled). It is possible for 2 buffers to be completed, so clearing the buffer status bit may instantly re set it on the next clock cycle."]
 pub mod buff_status;
 #[doc = "Which of the double buffers should be handled. Only valid if using an interrupt per buffer (i.e. not per 2 buffers). Not valid for host interrupt endpoint polling because they are only single buffered.\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [buff_cpu_should_handle](buff_cpu_should_handle) module"]

--- a/src/usbctrl_regs/buff_status.rs
+++ b/src/usbctrl_regs/buff_status.rs
@@ -1,69 +1,783 @@
 #[doc = "Reader of register BUFF_STATUS"]
 pub type R = crate::R<u32, super::BUFF_STATUS>;
+#[doc = "Writer for register BUFF_STATUS"]
+pub type W = crate::W<u32, super::BUFF_STATUS>;
+#[doc = "Register BUFF_STATUS `reset()`'s with value 0"]
+impl crate::ResetValue for super::BUFF_STATUS {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
 #[doc = "Reader of field `EP15_OUT`"]
 pub type EP15_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP15_OUT`"]
+pub struct EP15_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP15_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 31)) | (((value as u32) & 0x01) << 31);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP15_IN`"]
 pub type EP15_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP15_IN`"]
+pub struct EP15_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP15_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 30)) | (((value as u32) & 0x01) << 30);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP14_OUT`"]
 pub type EP14_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP14_OUT`"]
+pub struct EP14_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP14_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 29)) | (((value as u32) & 0x01) << 29);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP14_IN`"]
 pub type EP14_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP14_IN`"]
+pub struct EP14_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP14_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 28)) | (((value as u32) & 0x01) << 28);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP13_OUT`"]
 pub type EP13_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP13_OUT`"]
+pub struct EP13_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP13_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 27)) | (((value as u32) & 0x01) << 27);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP13_IN`"]
 pub type EP13_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP13_IN`"]
+pub struct EP13_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP13_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 26)) | (((value as u32) & 0x01) << 26);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP12_OUT`"]
 pub type EP12_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP12_OUT`"]
+pub struct EP12_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP12_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 25)) | (((value as u32) & 0x01) << 25);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP12_IN`"]
 pub type EP12_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP12_IN`"]
+pub struct EP12_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP12_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 24)) | (((value as u32) & 0x01) << 24);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP11_OUT`"]
 pub type EP11_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP11_OUT`"]
+pub struct EP11_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP11_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 23)) | (((value as u32) & 0x01) << 23);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP11_IN`"]
 pub type EP11_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP11_IN`"]
+pub struct EP11_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP11_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 22)) | (((value as u32) & 0x01) << 22);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP10_OUT`"]
 pub type EP10_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP10_OUT`"]
+pub struct EP10_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP10_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 21)) | (((value as u32) & 0x01) << 21);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP10_IN`"]
 pub type EP10_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP10_IN`"]
+pub struct EP10_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP10_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 20)) | (((value as u32) & 0x01) << 20);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP9_OUT`"]
 pub type EP9_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP9_OUT`"]
+pub struct EP9_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP9_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP9_IN`"]
 pub type EP9_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP9_IN`"]
+pub struct EP9_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP9_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP8_OUT`"]
 pub type EP8_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP8_OUT`"]
+pub struct EP8_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP8_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP8_IN`"]
 pub type EP8_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP8_IN`"]
+pub struct EP8_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP8_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP7_OUT`"]
 pub type EP7_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP7_OUT`"]
+pub struct EP7_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP7_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP7_IN`"]
 pub type EP7_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP7_IN`"]
+pub struct EP7_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP7_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u32) & 0x01) << 14);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP6_OUT`"]
 pub type EP6_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP6_OUT`"]
+pub struct EP6_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP6_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP6_IN`"]
 pub type EP6_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP6_IN`"]
+pub struct EP6_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP6_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP5_OUT`"]
 pub type EP5_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP5_OUT`"]
+pub struct EP5_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP5_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP5_IN`"]
 pub type EP5_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP5_IN`"]
+pub struct EP5_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP5_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP4_OUT`"]
 pub type EP4_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP4_OUT`"]
+pub struct EP4_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP4_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP4_IN`"]
 pub type EP4_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP4_IN`"]
+pub struct EP4_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP4_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP3_OUT`"]
 pub type EP3_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP3_OUT`"]
+pub struct EP3_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP3_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP3_IN`"]
 pub type EP3_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP3_IN`"]
+pub struct EP3_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP3_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP2_OUT`"]
 pub type EP2_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP2_OUT`"]
+pub struct EP2_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP2_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP2_IN`"]
 pub type EP2_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP2_IN`"]
+pub struct EP2_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP2_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP1_OUT`"]
 pub type EP1_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP1_OUT`"]
+pub struct EP1_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP1_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP1_IN`"]
 pub type EP1_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP1_IN`"]
+pub struct EP1_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP1_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP0_OUT`"]
 pub type EP0_OUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP0_OUT`"]
+pub struct EP0_OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP0_OUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
 #[doc = "Reader of field `EP0_IN`"]
 pub type EP0_IN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EP0_IN`"]
+pub struct EP0_IN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EP0_IN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
 impl R {
     #[doc = "Bit 31"]
     #[inline(always)]
@@ -224,5 +938,167 @@ impl R {
     #[inline(always)]
     pub fn ep0_in(&self) -> EP0_IN_R {
         EP0_IN_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 31"]
+    #[inline(always)]
+    pub fn ep15_out(&mut self) -> EP15_OUT_W {
+        EP15_OUT_W { w: self }
+    }
+    #[doc = "Bit 30"]
+    #[inline(always)]
+    pub fn ep15_in(&mut self) -> EP15_IN_W {
+        EP15_IN_W { w: self }
+    }
+    #[doc = "Bit 29"]
+    #[inline(always)]
+    pub fn ep14_out(&mut self) -> EP14_OUT_W {
+        EP14_OUT_W { w: self }
+    }
+    #[doc = "Bit 28"]
+    #[inline(always)]
+    pub fn ep14_in(&mut self) -> EP14_IN_W {
+        EP14_IN_W { w: self }
+    }
+    #[doc = "Bit 27"]
+    #[inline(always)]
+    pub fn ep13_out(&mut self) -> EP13_OUT_W {
+        EP13_OUT_W { w: self }
+    }
+    #[doc = "Bit 26"]
+    #[inline(always)]
+    pub fn ep13_in(&mut self) -> EP13_IN_W {
+        EP13_IN_W { w: self }
+    }
+    #[doc = "Bit 25"]
+    #[inline(always)]
+    pub fn ep12_out(&mut self) -> EP12_OUT_W {
+        EP12_OUT_W { w: self }
+    }
+    #[doc = "Bit 24"]
+    #[inline(always)]
+    pub fn ep12_in(&mut self) -> EP12_IN_W {
+        EP12_IN_W { w: self }
+    }
+    #[doc = "Bit 23"]
+    #[inline(always)]
+    pub fn ep11_out(&mut self) -> EP11_OUT_W {
+        EP11_OUT_W { w: self }
+    }
+    #[doc = "Bit 22"]
+    #[inline(always)]
+    pub fn ep11_in(&mut self) -> EP11_IN_W {
+        EP11_IN_W { w: self }
+    }
+    #[doc = "Bit 21"]
+    #[inline(always)]
+    pub fn ep10_out(&mut self) -> EP10_OUT_W {
+        EP10_OUT_W { w: self }
+    }
+    #[doc = "Bit 20"]
+    #[inline(always)]
+    pub fn ep10_in(&mut self) -> EP10_IN_W {
+        EP10_IN_W { w: self }
+    }
+    #[doc = "Bit 19"]
+    #[inline(always)]
+    pub fn ep9_out(&mut self) -> EP9_OUT_W {
+        EP9_OUT_W { w: self }
+    }
+    #[doc = "Bit 18"]
+    #[inline(always)]
+    pub fn ep9_in(&mut self) -> EP9_IN_W {
+        EP9_IN_W { w: self }
+    }
+    #[doc = "Bit 17"]
+    #[inline(always)]
+    pub fn ep8_out(&mut self) -> EP8_OUT_W {
+        EP8_OUT_W { w: self }
+    }
+    #[doc = "Bit 16"]
+    #[inline(always)]
+    pub fn ep8_in(&mut self) -> EP8_IN_W {
+        EP8_IN_W { w: self }
+    }
+    #[doc = "Bit 15"]
+    #[inline(always)]
+    pub fn ep7_out(&mut self) -> EP7_OUT_W {
+        EP7_OUT_W { w: self }
+    }
+    #[doc = "Bit 14"]
+    #[inline(always)]
+    pub fn ep7_in(&mut self) -> EP7_IN_W {
+        EP7_IN_W { w: self }
+    }
+    #[doc = "Bit 13"]
+    #[inline(always)]
+    pub fn ep6_out(&mut self) -> EP6_OUT_W {
+        EP6_OUT_W { w: self }
+    }
+    #[doc = "Bit 12"]
+    #[inline(always)]
+    pub fn ep6_in(&mut self) -> EP6_IN_W {
+        EP6_IN_W { w: self }
+    }
+    #[doc = "Bit 11"]
+    #[inline(always)]
+    pub fn ep5_out(&mut self) -> EP5_OUT_W {
+        EP5_OUT_W { w: self }
+    }
+    #[doc = "Bit 10"]
+    #[inline(always)]
+    pub fn ep5_in(&mut self) -> EP5_IN_W {
+        EP5_IN_W { w: self }
+    }
+    #[doc = "Bit 9"]
+    #[inline(always)]
+    pub fn ep4_out(&mut self) -> EP4_OUT_W {
+        EP4_OUT_W { w: self }
+    }
+    #[doc = "Bit 8"]
+    #[inline(always)]
+    pub fn ep4_in(&mut self) -> EP4_IN_W {
+        EP4_IN_W { w: self }
+    }
+    #[doc = "Bit 7"]
+    #[inline(always)]
+    pub fn ep3_out(&mut self) -> EP3_OUT_W {
+        EP3_OUT_W { w: self }
+    }
+    #[doc = "Bit 6"]
+    #[inline(always)]
+    pub fn ep3_in(&mut self) -> EP3_IN_W {
+        EP3_IN_W { w: self }
+    }
+    #[doc = "Bit 5"]
+    #[inline(always)]
+    pub fn ep2_out(&mut self) -> EP2_OUT_W {
+        EP2_OUT_W { w: self }
+    }
+    #[doc = "Bit 4"]
+    #[inline(always)]
+    pub fn ep2_in(&mut self) -> EP2_IN_W {
+        EP2_IN_W { w: self }
+    }
+    #[doc = "Bit 3"]
+    #[inline(always)]
+    pub fn ep1_out(&mut self) -> EP1_OUT_W {
+        EP1_OUT_W { w: self }
+    }
+    #[doc = "Bit 2"]
+    #[inline(always)]
+    pub fn ep1_in(&mut self) -> EP1_IN_W {
+        EP1_IN_W { w: self }
+    }
+    #[doc = "Bit 1"]
+    #[inline(always)]
+    pub fn ep0_out(&mut self) -> EP0_OUT_W {
+        EP0_OUT_W { w: self }
+    }
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn ep0_in(&mut self) -> EP0_IN_W {
+        EP0_IN_W { w: self }
     }
 }

--- a/svd/rp2040.svd.patched
+++ b/svd/rp2040.svd.patched
@@ -26788,162 +26788,162 @@
             <field>
               <name>EP15_OUT</name>
             <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP15_IN</name>
             <bitRange>[30:30]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP14_OUT</name>
             <bitRange>[29:29]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP14_IN</name>
             <bitRange>[28:28]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP13_OUT</name>
             <bitRange>[27:27]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP13_IN</name>
             <bitRange>[26:26]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP12_OUT</name>
             <bitRange>[25:25]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP12_IN</name>
             <bitRange>[24:24]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP11_OUT</name>
             <bitRange>[23:23]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP11_IN</name>
             <bitRange>[22:22]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP10_OUT</name>
             <bitRange>[21:21]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP10_IN</name>
             <bitRange>[20:20]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP9_OUT</name>
             <bitRange>[19:19]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP9_IN</name>
             <bitRange>[18:18]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP8_OUT</name>
             <bitRange>[17:17]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP8_IN</name>
             <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP7_OUT</name>
             <bitRange>[15:15]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP7_IN</name>
             <bitRange>[14:14]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP6_OUT</name>
             <bitRange>[13:13]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP6_IN</name>
             <bitRange>[12:12]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP5_OUT</name>
             <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP5_IN</name>
             <bitRange>[10:10]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP4_OUT</name>
             <bitRange>[9:9]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP4_IN</name>
             <bitRange>[8:8]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP3_OUT</name>
             <bitRange>[7:7]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP3_IN</name>
             <bitRange>[6:6]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP2_OUT</name>
             <bitRange>[5:5]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP2_IN</name>
             <bitRange>[4:4]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP1_OUT</name>
             <bitRange>[3:3]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP1_IN</name>
             <bitRange>[2:2]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP0_OUT</name>
             <bitRange>[1:1]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>EP0_IN</name>
             <bitRange>[0:0]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
           </fields>
           </register>

--- a/svd/rp2040.yaml
+++ b/svd/rp2040.yaml
@@ -31,3 +31,12 @@ IO_QSPI:
     "GPIO_QSPI%s":
       "GPIO_QSPI_*_STATUS": {}
       "GPIO_QSPI_*_CTRL": {}
+
+USBCTRL_REGS:
+  # BUFF_STATUS is read-only in the SVD and datasheet, but used as read-write
+  # in the example code (see https://github.com/raspberrypi/pico-feedback/issues/36).
+  BUFF_STATUS:
+    _modify:
+      "EP*":
+        access: read-write
+


### PR DESCRIPTION
The BUFF_STATUS register is currently marked as read-only
in the SVD and datasheet, but is used as read-write register
in the SDK code.

See also https://github.com/raspberrypi/pico-feedback/issues/36.
