### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ Working on patching the svd for better workflow, using [svdtools](https://pypi.o
 ## Release 0.1.1
 [Release 0.1.1 on Crates.io](https://crates.io/crates/rp2040-pac/0.1.1)
 
+[Release 0.1.1 on GitHub](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.1.1)
+
 Alphabetized Peripherals
 
 ## Release 0.1.0
 [Release 0.1.0 on Crates.io](https://crates.io/crates/rp2040-pac/0.1.0)
+
+[Release 0.1.0 on GitHub](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.1.0)
 
 Created using svd2rust 0.17.0 from https://github.com/raspberrypi/pico-sdk/blob/1.0.0/src/rp2040/hardware_regs/rp2040.svd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ Working on patching the svd for better workflow, using [svdtools](https://pypi.o
 
 [Release 0.1.1 on GitHub](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.1.1)
 
-Alphabetized Peripherals
+- Created using svd2rust 0.17.0 from https://github.com/raspberrypi/pico-sdk/blob/1.0.0/src/rp2040/hardware_regs/rp2040.svd
+- Alphabetized Peripherals
 
 ## Release 0.1.0
 [Release 0.1.0 on Crates.io](https://crates.io/crates/rp2040-pac/0.1.0)
 
 [Release 0.1.0 on GitHub](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.1.0)
 
-Created using svd2rust 0.17.0 from https://github.com/raspberrypi/pico-sdk/blob/1.0.0/src/rp2040/hardware_regs/rp2040.svd
+- Initialized crate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,14 @@
 
 ## Unreleased Changes
 
+Working on patching the svd for better workflow, using [svdtools](https://pypi.org/project/svdtools/)
+
+## Release 0.1.1
+[Release 0.1.1 on Crates.io](https://crates.io/crates/rp2040-pac/0.1.1)
+
+Alphabetized Peripherals
+
+## Release 0.1.0
+[Release 0.1.0 on Crates.io](https://crates.io/crates/rp2040-pac/0.1.0)
+
 Created using svd2rust 0.17.0 from https://github.com/raspberrypi/pico-sdk/blob/1.0.0/src/rp2040/hardware_regs/rp2040.svd


### PR DESCRIPTION
Updated CHANGELOG.md, now reflects the 0.1.0/1 releases on Crates.io

In reference to #14

Will tag relevant commits next and add links to GitHub releases.