### PR TITLE
Version bump to get a new release out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 Working on patching the svd for better workflow, using [svdtools](https://pypi.org/project/svdtools/)
 
+## Release 0.1.2
+[Release 0.1.2 on Crates.io](https://crates.io/crates/rp2040-pac/0.1.2)
+
+[Release 0.1.2 on GitHub](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.1.2)
+
+- Switched GPIO for IO_BANK and QSPI_BANK to be arrays instead.
+- Change BUFF_STATUS access to read-write
+- Re-clustered IO_QSPI. Fixed naming to remove double underscore
+- Renamed GPIO_QSPI_[STAT,CTRL] -> GPIO_[STAT,CTRL]
+- Convert DMA chunnels to a list of register clusters
+
 ## Release 0.1.1
 [Release 0.1.1 on Crates.io](https://crates.io/crates/rp2040-pac/0.1.1)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-pac"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["eolder <evanmolder@gmail.com>", "Jonathan Pallant <github@thejpster.org.uk>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp2040-pac"

--- a/svd/rp2040.svd.patched
+++ b/svd/rp2040.svd.patched
@@ -1,4 +1,8 @@
-<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+<!--
+  Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+
+  SPDX-License-Identifier: BSD-3-Clause
+--><device xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
   <vendor>Raspberry Pi</vendor>
   <name>RP2040</name>
   <version>0.1</version>

--- a/update.sh
+++ b/update.sh
@@ -7,6 +7,7 @@ set -ex
 cargo install --version 0.17.0 svd2rust
 cargo install --version 0.7.0  form
 rustup component add rustfmt
+pip3 install --upgrade --user "svdtools>=0.1.13"
 
 rm -rf src
 mkdir src


### PR DESCRIPTION
There's been a few changes since the last release, and downstream users are depending on these changes.
This is just the manual tasks that need to be performed before a release.

I did hit an issue during rebuilding due to not having a new enough svdtools, so I added a line update.sh to install a version that was compatible.
First thing after this release we should upgrade svd2rust+form+crate deps as a seperate step.