### PR TITLE
Update to newest version of cortex-m, do a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 Working on patching the svd for better workflow, using [svdtools](https://pypi.org/project/svdtools/)
 
+## Release 0.1.3
+[Release 0.1.3 on Crates.io](https://crates.io/crates/rp2040-pac/0.1.3)
+
+[Release 0.1.3 on GitHub](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.1.3)
+
+- Update source SVD to pico-sdk 1.2.0
+- Cluster PWM channels
+- Bump cortex-m dep to 0.7.3
+
 ## Release 0.1.2
 [Release 0.1.2 on Crates.io](https://crates.io/crates/rp2040-pac/0.1.2)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-pac"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["eolder <evanmolder@gmail.com>", "Jonathan Pallant <github@thejpster.org.uk>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp2040-pac"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "A Peripheral Access Crate for the Raspberry Pi RP2040 SoC"
 license-file = "svd/rp2040.svd"
 
 [dependencies]
-cortex-m = "0.7.1"
+cortex-m = "0.7.3"
 vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]


### PR DESCRIPTION
Only functional change in this PR is updating cortex-m
Other than that, just bumping the pac version number and updating release notes.
I wanted to update the build tools (svd2rust, form) but doing so will require some fix-ups on rp-hal at the same time, so it makes sense to depend on a release version first.
