### PR TITLE
Allow both c-m-rt 0.6 and 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.7.0"
+version = ">=0.6.15,<0.8"
 
 [features]
 rt = ["cortex-m-rt/device"]


### PR DESCRIPTION
RTIC v0.5.x requires cortex-m-rt 0.6
In order to use current RTIC projects or the [microamp](https://github.com/rtic-rs/microamp) you need to use RTIC v0.5.x
By specifying the dependency as a range, downstream users can pick c-m-rt 0.6 or get the default of 0.7 as they currently do.
I'm sure there are other uses of this but RTIC 0.5 compatibility is the main one for me.