### PR TITLE
Fix SIE_STATUS patch not being applied due to duplicate YAML key

### DIFF
--- a/svd/rp2040.svd.patched
+++ b/svd/rp2040.svd.patched
@@ -21138,7 +21138,7 @@
               <name>CONNECTED</name>
             <description>Device: connected</description>
               <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
+              <access>read-write</access>
               </field>
             <field>
               <name>RESUME</name>

--- a/svd/rp2040.yaml
+++ b/svd/rp2040.yaml
@@ -89,11 +89,16 @@ USBCTRL_REGS:
     _modify:
       "EP*":
         access: read-write
-  # CONNECTED is implied to be read-write https://github.com/raspberrypi/pico-feedback/issues/110
   SIE_STATUS:
     _modify:
+      # CONNECTED is implied to be read-write https://github.com/raspberrypi/pico-feedback/issues/110
       CONNECTED:
           access: "read-write"
+    LINE_STATE:
+      SE0: [0, "SE0"]
+      J: [1, "J"]
+      K: [2, "K"]
+      SE1: [3, "SE1"]
 
 ROSC:
   _delete:
@@ -141,14 +146,6 @@ SIO:
         access: read-write
       "SPINLOCK3[01]":
         access: read-write
-
-USBCTRL_REGS:
-  SIE_STATUS:
-    LINE_STATE:
-      SE0: [0, "SE0"]
-      J: [1, "J"]
-      K: [2, "K"]
-      SE1: [3, "SE1"]
 
 USBCTRL_DPRAM:
   _modify:


### PR DESCRIPTION
I'm updating svdtools to detect and reject duplicate YAML keys, because currently they'll cause a silent error where some patches will simply not be applied (in YAML it's not permitted to have duplicate keys in one mapping, but the Python parsers silently accept it). https://github.com/stm32-rs/svdtools/pull/72

Since the RP2040 PAC is now in the svdtools CI, it needs to build before the PR will merge, and it turns out there is one small such problem here, fixed in this PR.