### PR TITLE
Do v0.1.6 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- None
+
+## [0.1.6] [Crates.io](https://crates.io/crates/rp2040-pac/0.1.6) [Github](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.1.6)
+
 - Update source SVD to pico-sdk 1.3.0
 - Remove patches that were no longer required thanks to new SVD file.
+- Arrayify `procX_intX` registers in `IO_BANK1`.
 
 ## [0.1.5] [Crates.io](https://crates.io/crates/rp2040-pac/0.1.5) [Github](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.1.5)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-pac"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["eolder <evanmolder@gmail.com>", "Jonathan Pallant <github@thejpster.org.uk>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp2040-pac"


### PR DESCRIPTION
Once merged, we must:

1. Tag main as v0.1.6
2. Create a v0.1.6 release in Github
3. Do a cargo publish on a clean checkout of the tag.

A dry-run seems to work:

```
$ cargo publish --dry-run
    Updating crates.io index
   Packaging rp2040-pac v0.1.6 (/home/jonathan/Documents/rp-rs/rp2040-pac)
   Verifying rp2040-pac v0.1.6 (/home/jonathan/Documents/rp-rs/rp2040-pac)
   Compiling semver-parser v0.7.0
   Compiling cortex-m v0.7.3
   Compiling nb v1.0.0
   Compiling vcell v0.1.3
   Compiling void v1.0.2
   Compiling bitfield v0.13.2
   Compiling rp2040-pac v0.1.6 (/home/jonathan/Documents/rp-rs/rp2040-pac/target/package/rp2040-pac-0.1.6)
   Compiling volatile-register v0.2.1
   Compiling nb v0.1.3
   Compiling embedded-hal v0.2.6
   Compiling semver v0.9.0
   Compiling rustc_version v0.2.3
   Compiling bare-metal v0.2.5
    Finished dev [unoptimized + debuginfo] target(s) in 8.47s
   Uploading rp2040-pac v0.1.6 (/home/jonathan/Documents/rp-rs/rp2040-pac)
warning: aborting upload due to dry run

```