### PR TITLE
Remove "last built with rust [ver]" comment

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -2,8 +2,6 @@
 
 set -ex
 
-# NOTE: Last executed using Rust 1.49.0
-
 cargo install --version 0.21.0 svd2rust
 cargo install --version 0.8.0  form
 rustup component add rustfmt


### PR DESCRIPTION
We do not have a MSRV (Minimum Supported Rust Version) for this crate, the tools we're relying on are on crates.io so they should be able to run on newer Rust versions.
So remove the "last built with" comment from update.sh, as it wasn't being actively maintained.

Closes #53