### PR TITLE
Add unused IRQs as software IRQs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added all possible variants for DREQ enum in CH*_CTRL*
 - Update rustdoc to clarify DMA CHAIN_TO behaviour
+- Add 6 unused interrupts as sw[0..5]_irq under new SW_IRQ peripheral
 
 ## [0.3.0] [Crates.io](https://crates.io/crates/rp2040-pac/0.3.0) [Github](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.3.0)
 

--- a/device.x
+++ b/device.x
@@ -24,4 +24,9 @@ PROVIDE(ADC_IRQ_FIFO = DefaultHandler);
 PROVIDE(I2C0_IRQ = DefaultHandler);
 PROVIDE(I2C1_IRQ = DefaultHandler);
 PROVIDE(RTC_IRQ = DefaultHandler);
-
+PROVIDE(SOFT_0_IRQ = DefaultHandler);
+PROVIDE(SOFT_1_IRQ = DefaultHandler);
+PROVIDE(SOFT_2_IRQ = DefaultHandler);
+PROVIDE(SOFT_3_IRQ = DefaultHandler);
+PROVIDE(SOFT_4_IRQ = DefaultHandler);
+PROVIDE(SOFT_5_IRQ = DefaultHandler);

--- a/device.x
+++ b/device.x
@@ -24,9 +24,10 @@ PROVIDE(ADC_IRQ_FIFO = DefaultHandler);
 PROVIDE(I2C0_IRQ = DefaultHandler);
 PROVIDE(I2C1_IRQ = DefaultHandler);
 PROVIDE(RTC_IRQ = DefaultHandler);
-PROVIDE(SOFT_0_IRQ = DefaultHandler);
-PROVIDE(SOFT_1_IRQ = DefaultHandler);
-PROVIDE(SOFT_2_IRQ = DefaultHandler);
-PROVIDE(SOFT_3_IRQ = DefaultHandler);
-PROVIDE(SOFT_4_IRQ = DefaultHandler);
-PROVIDE(SOFT_5_IRQ = DefaultHandler);
+PROVIDE(SW0_IRQ = DefaultHandler);
+PROVIDE(SW1_IRQ = DefaultHandler);
+PROVIDE(SW2_IRQ = DefaultHandler);
+PROVIDE(SW3_IRQ = DefaultHandler);
+PROVIDE(SW4_IRQ = DefaultHandler);
+PROVIDE(SW5_IRQ = DefaultHandler);
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,12 @@ extern "C" {
     fn I2C0_IRQ();
     fn I2C1_IRQ();
     fn RTC_IRQ();
+    fn SW0_IRQ();
+    fn SW1_IRQ();
+    fn SW2_IRQ();
+    fn SW3_IRQ();
+    fn SW4_IRQ();
+    fn SW5_IRQ();
 }
 #[doc(hidden)]
 pub union Vector {
@@ -78,7 +84,7 @@ pub union Vector {
 #[doc(hidden)]
 #[link_section = ".vector_table.interrupts"]
 #[no_mangle]
-pub static __INTERRUPTS: [Vector; 26] = [
+pub static __INTERRUPTS: [Vector; 32] = [
     Vector {
         _handler: TIMER_IRQ_0,
     },
@@ -145,6 +151,12 @@ pub static __INTERRUPTS: [Vector; 26] = [
     Vector { _handler: I2C0_IRQ },
     Vector { _handler: I2C1_IRQ },
     Vector { _handler: RTC_IRQ },
+    Vector { _handler: SW0_IRQ },
+    Vector { _handler: SW1_IRQ },
+    Vector { _handler: SW2_IRQ },
+    Vector { _handler: SW3_IRQ },
+    Vector { _handler: SW4_IRQ },
+    Vector { _handler: SW5_IRQ },
 ];
 #[doc = r"Enumeration of all the interrupts."]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -202,6 +214,18 @@ pub enum Interrupt {
     I2C1_IRQ = 24,
     #[doc = "25 - RTC_IRQ"]
     RTC_IRQ = 25,
+    #[doc = "26 - Software IRQ 0"]
+    SW0_IRQ = 26,
+    #[doc = "27 - Software IRQ 1"]
+    SW1_IRQ = 27,
+    #[doc = "28 - Software IRQ 2"]
+    SW2_IRQ = 28,
+    #[doc = "29 - Software IRQ 3"]
+    SW3_IRQ = 29,
+    #[doc = "30 - Software IRQ 4"]
+    SW4_IRQ = 30,
+    #[doc = "31 - Software IRQ 5"]
+    SW5_IRQ = 31,
 }
 unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline(always)]

--- a/svd/rp2040.svd.patched
+++ b/svd/rp2040.svd.patched
@@ -21408,5 +21408,12 @@
           </register>
       </registers>
       </peripheral>
-  </peripherals>
+  <peripheral><name>SW_IRQ</name><description>Virtual Peripheral to access unused NVIC software interrupts</description><baseAddress>0</baseAddress><interrupt><name>sw0_irq</name><description>Software IRQ 0</description><value>26</value></interrupt>
+    <interrupt><name>sw1_irq</name><description>Software IRQ 1</description><value>27</value></interrupt>
+    <interrupt><name>sw2_irq</name><description>Software IRQ 2</description><value>28</value></interrupt>
+    <interrupt><name>sw3_irq</name><description>Software IRQ 3</description><value>29</value></interrupt>
+    <interrupt><name>sw4_irq</name><description>Software IRQ 4</description><value>30</value></interrupt>
+    <interrupt><name>sw5_irq</name><description>Software IRQ 5</description><value>31</value></interrupt>
+    </peripheral>
+    </peripherals>
 </device>

--- a/svd/rp2040.yaml
+++ b/svd/rp2040.yaml
@@ -710,3 +710,27 @@ USBCTRL_DPRAM:
     "EP*_IN_CONTROL,EP*_OUT_CONTROL":
         _start_from_zero: true
         name: "EP_CONTROL%s"
+
+_add:
+  SW_IRQ:
+    description: Virtual Peripheral to access unused NVIC software interrupts
+    baseAddress: 0
+    interrupts:
+      sw0_irq:
+        description: "Software IRQ 0"
+        value: 26
+      sw1_irq:
+        description: "Software IRQ 1"
+        value: 27
+      sw2_irq:
+        description: "Software IRQ 2"
+        value: 28
+      sw3_irq:
+        description: "Software IRQ 3"
+        value: 29
+      sw4_irq:
+        description: "Software IRQ 4"
+        value: 30
+      sw5_irq:
+        description: "Software IRQ 5"
+        value: 31


### PR DESCRIPTION
The upper 6 interrupts in each NVIC are not connected to hardware, but could still be used for software IRQ (for example, RTIC can use these for software tasks).
Interrupts have to live under a peripheral, so I added SW_IRQ at address 0x0 to group them under.
Since there a no fields in this peripheral it should not matter what the address is, if I understand it correctly. We could also append them to an existing peripheral if this is a concern.
This was brought up in [#236](https://github.com/rp-rs/rp-hal/issues/236)