### PR TITLE
Disable clippy::derive_partial_eq_without_eq warning

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -Dwarnings
+          args: -- -A clippy::derive_partial_eq_without_eq -Dwarnings


### PR DESCRIPTION
Rust 1.63 clippy added a lint that is being triggered by svd2rust output.
Disable that lint in CI for now.

Here's what the lint warning looks like:
```
warning: you are deriving `PartialEq` and can implement `Eq`
   --> src/usbctrl_regs/sie_status.rs:632:30
    |
632 | #[derive(Clone, Copy, Debug, PartialEq)]
    |                              ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
```