### PR TITLE
Update crate version and changelog for release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] [Crates.io](https://crates.io/crates/rp2040-pac/0.4.0) [Github](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.4.0)
+
 - Added all possible variants for DREQ enum in CH*_CTRL*
 - Update rustdoc to clarify DMA CHAIN_TO behaviour
 - Add 6 unused interrupts as sw[0..5]_irq under new SW_IRQ peripheral
+- Pin to specific svdtools to avoid spontaneous breakage
+- Disable clippy warning for derive_partial_eq_without_eq
 
 ## [0.3.0] [Crates.io](https://crates.io/crates/rp2040-pac/0.3.0) [Github](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add 6 unused interrupts as sw[0..5]_irq under new SW_IRQ peripheral
 - Pin to specific svdtools to avoid spontaneous breakage
 - Disable clippy warning for derive_partial_eq_without_eq
+- Update to SVD from pico-sdk 1.4.0
 
 ## [0.3.0] [Crates.io](https://crates.io/crates/rp2040-pac/0.3.0) [Github](https://github.com/rp-rs/rp2040-pac/releases/tag/v0.3.0)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-pac"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The RP-RS team"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp2040-pac"


### PR DESCRIPTION
Please wait for #66 to land before merging this.
I think we should leave #61 until after release, we need to resolve how we're fixing the registers that are incorrectly labelled as clear on write. And also some objects now need parens for some reason.

Resolves #65