### PR TITLE
Use critical section instead of disabling interrupts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["thumbv6m-none-eabi"]
 [dependencies]
 cortex-m = "0.7.3"
 vcell = "0.1.0"
+critical-section = "1.1"
 
 [dependencies.cortex-m-rt]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1677,7 +1677,7 @@ impl Peripherals {
     #[doc = r"Returns all the peripherals *once*"]
     #[inline]
     pub fn take() -> Option<Self> {
-        cortex_m::interrupt::free(|_| {
+        critical_section::with(|_| {
             if unsafe { DEVICE_PERIPHERALS } {
                 None
             } else {


### PR DESCRIPTION
This PR replaces an interruption-free section inside `Peripherals::take()` with more generic critical section using `critical_section` crate.

Critical sections implemented with just disabling interrupts are [unsound on multicore environments](https://github.com/rust-embedded/riscv/pull/110), because other core can still modify data.
`critical_section` crate can mitigate this problem because it can be implemented in multicore-safe way, [as in `rp2040-hal`](https://github.com/rp-rs/rp-hal/blob/cd4cb7baea9db9fa116fa81a3737277f56e5a987/rp2040-hal/src/critical_section_impl.rs).

Also, it improves compatibility with newer, unreleased version of `cortex-m` which has different signature of `interrupt::free`.