### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,13 +5,8 @@ jobs:
     name: cargo-check
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: thumbv6m-none-eabi
-          override: true
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
+      - run: cargo build

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,19 +6,9 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: thumbv6m-none-eabi
-          override: true
-          profile: minimal
           components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: >-
-            --
-            -A clippy::derive_partial_eq_without_eq
-            -A clippy::explicit_auto_deref
-            -D warnings
+      - run: cargo clippy -- -A clippy::derive_partial_eq_without_eq -A clippy::explicit_auto_deref -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,7 +7,7 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.64.0
         with:
           target: thumbv6m-none-eabi
           components: clippy

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -7,15 +7,9 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: thumbv6m-none-eabi
-          override: true
-          profile: minimal
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+      - run: cargo fmt --check

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,10 @@
+on: [push, pull_request]
+name: Run update.sh and check for changed files
+jobs:
+  check:
+    name: cargo-check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./update.sh
+      - run: git diff --exit-code


### PR DESCRIPTION
Update github workflows:
- Run update.sh and check for changed files, so we notice if the generated files in `src/` need to be updated
- Run clippy with a fixed rust version (1.64 for now), so the checks don't break at random times when new clippy lints get added
- Replace deprecated actions-rs actions