### PR TITLE
Bump dependency on vcell to version 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["thumbv6m-none-eabi"]
 
 [dependencies]
 cortex-m = "0.7.3"
-vcell = "0.1.0"
+vcell = "0.1.3"
 
 [dependencies.cortex-m-rt]
 optional = true


### PR DESCRIPTION
The depenency used to be on version 0.1.0, but the pac doesn't actually compile with that version:

```
error[E0599]: no method named `as_ptr` found for struct `vcell::VolatileCell` in the current scope
   --> src/generic.rs:101:23
    |
101 |         self.register.as_ptr()
    |                       ^^^^^^ method not found in `VolatileCell<<REG as RegisterSpec>::Ux>`
```

`as_ptr` was added in version 0.1.1 of vcell, but that version is marked as yanked for unknown reasons. (https://github.com/japaric/vcell/issues/13)

Version 0.1.2 would have been another option, but 0.1.3 contains a fix for https://github.com/japaric/vcell/issues/5 which looks important.