### PR TITLE
Add VSEL_A, enum for setting on-chip voltage regulator voltage

### DIFF
--- a/src/vreg_and_chip_reset/vreg.rs
+++ b/src/vreg_and_chip_reset/vreg.rs
@@ -58,7 +58,123 @@ pub type HIZ_W<'a, const O: u8> = crate::BitWriter<'a, VREG_SPEC, O>;
  1101 - 1.20V  
  1110 - 1.25V  
  1111 - 1.30V"]
-pub type VSEL_R = crate::FieldReader;
+pub type VSEL_R = crate::FieldReader<VSEL_A>;
+#[doc = "output voltage select  
+ 0000 to 0101 - 0.80V  
+ 0110 - 0.85V  
+ 0111 - 0.90V  
+ 1000 - 0.95V  
+ 1001 - 1.00V  
+ 1010 - 1.05V  
+ 1011 - 1.10V (default)  
+ 1100 - 1.15V  
+ 1101 - 1.20V  
+ 1110 - 1.25V  
+ 1111 - 1.30V  
+
+Value on reset: 11"]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum VSEL_A {
+    #[doc = "6: 0.85V"]
+    VOLTAGE0_85 = 6,
+    #[doc = "7: 0.90V"]
+    VOLTAGE0_90 = 7,
+    #[doc = "8: 0.95V"]
+    VOLTAGE0_95 = 8,
+    #[doc = "9: 1.00V"]
+    VOLTAGE1_00 = 9,
+    #[doc = "10: 1.05V"]
+    VOLTAGE1_05 = 10,
+    #[doc = "11: 1.10V (default)"]
+    VOLTAGE1_10 = 11,
+    #[doc = "12: 1.15V"]
+    VOLTAGE1_15 = 12,
+    #[doc = "13: 1.20V"]
+    VOLTAGE1_20 = 13,
+    #[doc = "14: 1.25V"]
+    VOLTAGE1_25 = 14,
+    #[doc = "15: 1.30V"]
+    VOLTAGE1_30 = 15,
+}
+impl From<VSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: VSEL_A) -> Self {
+        variant as _
+    }
+}
+impl crate::FieldSpec for VSEL_A {
+    type Ux = u8;
+}
+impl VSEL_R {
+    #[doc = "Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> Option<VSEL_A> {
+        match self.bits {
+            6 => Some(VSEL_A::VOLTAGE0_85),
+            7 => Some(VSEL_A::VOLTAGE0_90),
+            8 => Some(VSEL_A::VOLTAGE0_95),
+            9 => Some(VSEL_A::VOLTAGE1_00),
+            10 => Some(VSEL_A::VOLTAGE1_05),
+            11 => Some(VSEL_A::VOLTAGE1_10),
+            12 => Some(VSEL_A::VOLTAGE1_15),
+            13 => Some(VSEL_A::VOLTAGE1_20),
+            14 => Some(VSEL_A::VOLTAGE1_25),
+            15 => Some(VSEL_A::VOLTAGE1_30),
+            _ => None,
+        }
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE0_85`"]
+    #[inline(always)]
+    pub fn is_voltage0_85(&self) -> bool {
+        *self == VSEL_A::VOLTAGE0_85
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE0_90`"]
+    #[inline(always)]
+    pub fn is_voltage0_90(&self) -> bool {
+        *self == VSEL_A::VOLTAGE0_90
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE0_95`"]
+    #[inline(always)]
+    pub fn is_voltage0_95(&self) -> bool {
+        *self == VSEL_A::VOLTAGE0_95
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE1_00`"]
+    #[inline(always)]
+    pub fn is_voltage1_00(&self) -> bool {
+        *self == VSEL_A::VOLTAGE1_00
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE1_05`"]
+    #[inline(always)]
+    pub fn is_voltage1_05(&self) -> bool {
+        *self == VSEL_A::VOLTAGE1_05
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE1_10`"]
+    #[inline(always)]
+    pub fn is_voltage1_10(&self) -> bool {
+        *self == VSEL_A::VOLTAGE1_10
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE1_15`"]
+    #[inline(always)]
+    pub fn is_voltage1_15(&self) -> bool {
+        *self == VSEL_A::VOLTAGE1_15
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE1_20`"]
+    #[inline(always)]
+    pub fn is_voltage1_20(&self) -> bool {
+        *self == VSEL_A::VOLTAGE1_20
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE1_25`"]
+    #[inline(always)]
+    pub fn is_voltage1_25(&self) -> bool {
+        *self == VSEL_A::VOLTAGE1_25
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE1_30`"]
+    #[inline(always)]
+    pub fn is_voltage1_30(&self) -> bool {
+        *self == VSEL_A::VOLTAGE1_30
+    }
+}
 #[doc = "Field `VSEL` writer - output voltage select  
  0000 to 0101 - 0.80V  
  0110 - 0.85V  
@@ -71,7 +187,59 @@ pub type VSEL_R = crate::FieldReader;
  1101 - 1.20V  
  1110 - 1.25V  
  1111 - 1.30V"]
-pub type VSEL_W<'a, const O: u8> = crate::FieldWriter<'a, VREG_SPEC, 4, O>;
+pub type VSEL_W<'a, const O: u8> = crate::FieldWriter<'a, VREG_SPEC, 4, O, VSEL_A>;
+impl<'a, const O: u8> VSEL_W<'a, O> {
+    #[doc = "0.85V"]
+    #[inline(always)]
+    pub fn voltage0_85(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE0_85)
+    }
+    #[doc = "0.90V"]
+    #[inline(always)]
+    pub fn voltage0_90(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE0_90)
+    }
+    #[doc = "0.95V"]
+    #[inline(always)]
+    pub fn voltage0_95(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE0_95)
+    }
+    #[doc = "1.00V"]
+    #[inline(always)]
+    pub fn voltage1_00(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE1_00)
+    }
+    #[doc = "1.05V"]
+    #[inline(always)]
+    pub fn voltage1_05(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE1_05)
+    }
+    #[doc = "1.10V (default)"]
+    #[inline(always)]
+    pub fn voltage1_10(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE1_10)
+    }
+    #[doc = "1.15V"]
+    #[inline(always)]
+    pub fn voltage1_15(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE1_15)
+    }
+    #[doc = "1.20V"]
+    #[inline(always)]
+    pub fn voltage1_20(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE1_20)
+    }
+    #[doc = "1.25V"]
+    #[inline(always)]
+    pub fn voltage1_25(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE1_25)
+    }
+    #[doc = "1.30V"]
+    #[inline(always)]
+    pub fn voltage1_30(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE1_30)
+    }
+}
 #[doc = "Field `ROK` reader - regulation status  
  0=not in regulation, 1=in regulation"]
 pub type ROK_R = crate::BitReader;

--- a/src/vreg_and_chip_reset/vreg.rs
+++ b/src/vreg_and_chip_reset/vreg.rs
@@ -46,31 +46,9 @@ pub type HIZ_R = crate::BitReader;
 #[doc = "Field `HIZ` writer - high impedance mode select  
  0=not in high impedance mode, 1=in high impedance mode"]
 pub type HIZ_W<'a, const O: u8> = crate::BitWriter<'a, VREG_SPEC, O>;
-#[doc = "Field `VSEL` reader - output voltage select  
- 0000 to 0101 - 0.80V  
- 0110 - 0.85V  
- 0111 - 0.90V  
- 1000 - 0.95V  
- 1001 - 1.00V  
- 1010 - 1.05V  
- 1011 - 1.10V (default)  
- 1100 - 1.15V  
- 1101 - 1.20V  
- 1110 - 1.25V  
- 1111 - 1.30V"]
+#[doc = "Field `VSEL` reader - Output voltage select for on-chip voltage regulator."]
 pub type VSEL_R = crate::FieldReader<VSEL_A>;
-#[doc = "output voltage select  
- 0000 to 0101 - 0.80V  
- 0110 - 0.85V  
- 0111 - 0.90V  
- 1000 - 0.95V  
- 1001 - 1.00V  
- 1010 - 1.05V  
- 1011 - 1.10V (default)  
- 1100 - 1.15V  
- 1101 - 1.20V  
- 1110 - 1.25V  
- 1111 - 1.30V  
+#[doc = "Output voltage select for on-chip voltage regulator.  
 
 Value on reset: 11"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -175,18 +153,7 @@ impl VSEL_R {
         *self == VSEL_A::VOLTAGE1_30
     }
 }
-#[doc = "Field `VSEL` writer - output voltage select  
- 0000 to 0101 - 0.80V  
- 0110 - 0.85V  
- 0111 - 0.90V  
- 1000 - 0.95V  
- 1001 - 1.00V  
- 1010 - 1.05V  
- 1011 - 1.10V (default)  
- 1100 - 1.15V  
- 1101 - 1.20V  
- 1110 - 1.25V  
- 1111 - 1.30V"]
+#[doc = "Field `VSEL` writer - Output voltage select for on-chip voltage regulator."]
 pub type VSEL_W<'a, const O: u8> = crate::FieldWriter<'a, VREG_SPEC, 4, O, VSEL_A>;
 impl<'a, const O: u8> VSEL_W<'a, O> {
     #[doc = "0.85V"]
@@ -256,18 +223,7 @@ impl R {
     pub fn hiz(&self) -> HIZ_R {
         HIZ_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bits 4:7 - output voltage select  
- 0000 to 0101 - 0.80V  
- 0110 - 0.85V  
- 0111 - 0.90V  
- 1000 - 0.95V  
- 1001 - 1.00V  
- 1010 - 1.05V  
- 1011 - 1.10V (default)  
- 1100 - 1.15V  
- 1101 - 1.20V  
- 1110 - 1.25V  
- 1111 - 1.30V"]
+    #[doc = "Bits 4:7 - Output voltage select for on-chip voltage regulator."]
     #[inline(always)]
     pub fn vsel(&self) -> VSEL_R {
         VSEL_R::new(((self.bits >> 4) & 0x0f) as u8)
@@ -294,18 +250,7 @@ impl W {
     pub fn hiz(&mut self) -> HIZ_W<1> {
         HIZ_W::new(self)
     }
-    #[doc = "Bits 4:7 - output voltage select  
- 0000 to 0101 - 0.80V  
- 0110 - 0.85V  
- 0111 - 0.90V  
- 1000 - 0.95V  
- 1001 - 1.00V  
- 1010 - 1.05V  
- 1011 - 1.10V (default)  
- 1100 - 1.15V  
- 1101 - 1.20V  
- 1110 - 1.25V  
- 1111 - 1.30V"]
+    #[doc = "Bits 4:7 - Output voltage select for on-chip voltage regulator."]
     #[inline(always)]
     #[must_use]
     pub fn vsel(&mut self) -> VSEL_W<4> {

--- a/src/vreg_and_chip_reset/vreg.rs
+++ b/src/vreg_and_chip_reset/vreg.rs
@@ -54,6 +54,8 @@ Value on reset: 11"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum VSEL_A {
+    #[doc = "5: 0.80V"]
+    VOLTAGE0_80 = 5,
     #[doc = "6: 0.85V"]
     VOLTAGE0_85 = 6,
     #[doc = "7: 0.90V"]
@@ -89,6 +91,7 @@ impl VSEL_R {
     #[inline(always)]
     pub fn variant(&self) -> Option<VSEL_A> {
         match self.bits {
+            5 => Some(VSEL_A::VOLTAGE0_80),
             6 => Some(VSEL_A::VOLTAGE0_85),
             7 => Some(VSEL_A::VOLTAGE0_90),
             8 => Some(VSEL_A::VOLTAGE0_95),
@@ -101,6 +104,11 @@ impl VSEL_R {
             15 => Some(VSEL_A::VOLTAGE1_30),
             _ => None,
         }
+    }
+    #[doc = "Checks if the value of the field is `VOLTAGE0_80`"]
+    #[inline(always)]
+    pub fn is_voltage0_80(&self) -> bool {
+        *self == VSEL_A::VOLTAGE0_80
     }
     #[doc = "Checks if the value of the field is `VOLTAGE0_85`"]
     #[inline(always)]
@@ -156,6 +164,11 @@ impl VSEL_R {
 #[doc = "Field `VSEL` writer - Output voltage select for on-chip voltage regulator."]
 pub type VSEL_W<'a, const O: u8> = crate::FieldWriter<'a, VREG_SPEC, 4, O, VSEL_A>;
 impl<'a, const O: u8> VSEL_W<'a, O> {
+    #[doc = "0.80V"]
+    #[inline(always)]
+    pub fn voltage0_80(self) -> &'a mut W {
+        self.variant(VSEL_A::VOLTAGE0_80)
+    }
     #[doc = "0.85V"]
     #[inline(always)]
     pub fn voltage0_85(self) -> &'a mut W {

--- a/svd/rp2040.svd.patched
+++ b/svd/rp2040.svd.patched
@@ -14581,6 +14581,60 @@
                 1111         - 1.30V</description>
               <bitRange>[7:4]</bitRange>
               <access>read-write</access>
+              <enumeratedValues>
+                <name>VSEL</name>
+                <usage>read-write</usage>
+                <enumeratedValue>
+                  <name>Voltage0_85</name>
+                  <description>0.85V</description>
+                  <value>6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Voltage0_90</name>
+                  <description>0.90V</description>
+                  <value>7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Voltage0_95</name>
+                  <description>0.95V</description>
+                  <value>8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Voltage1_00</name>
+                  <description>1.00V</description>
+                  <value>9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Voltage1_05</name>
+                  <description>1.05V</description>
+                  <value>10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Voltage1_10</name>
+                  <description>1.10V (default)</description>
+                  <value>11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Voltage1_15</name>
+                  <description>1.15V</description>
+                  <value>12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Voltage1_20</name>
+                  <description>1.20V</description>
+                  <value>13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Voltage1_25</name>
+                  <description>1.25V</description>
+                  <value>14</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Voltage1_30</name>
+                  <description>1.30V</description>
+                  <value>15</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>HIZ</name>

--- a/svd/rp2040.svd.patched
+++ b/svd/rp2040.svd.patched
@@ -14574,6 +14574,11 @@
                 <name>VSEL</name>
                 <usage>read-write</usage>
                 <enumeratedValue>
+                  <name>Voltage0_80</name>
+                  <description>0.80V</description>
+                  <value>5</value>
+                </enumeratedValue>
+                <enumeratedValue>
                   <name>Voltage0_85</name>
                   <description>0.85V</description>
                   <value>6</value>

--- a/svd/rp2040.svd.patched
+++ b/svd/rp2040.svd.patched
@@ -14567,18 +14567,7 @@
             </field>
             <field>
               <name>VSEL</name>
-              <description>output voltage select\n
-                0000 to 0101 - 0.80V\n
-                0110         - 0.85V\n
-                0111         - 0.90V\n
-                1000         - 0.95V\n
-                1001         - 1.00V\n
-                1010         - 1.05V\n
-                1011         - 1.10V (default)\n
-                1100         - 1.15V\n
-                1101         - 1.20V\n
-                1110         - 1.25V\n
-                1111         - 1.30V</description>
+              <description>Output voltage select for on-chip voltage regulator.</description>
               <bitRange>[7:4]</bitRange>
               <access>read-write</access>
               <enumeratedValues>

--- a/svd/rp2040.yaml
+++ b/svd/rp2040.yaml
@@ -651,6 +651,7 @@ VREG_AND_CHIP_RESET:
         description: "Output voltage select for on-chip voltage regulator."
     VSEL:
       _replace_enum:
+        Voltage0_80: [5, "0.80V"]
         Voltage0_85: [6, "0.85V"]
         Voltage0_90: [7, "0.90V"]
         Voltage0_95: [8, "0.95V"]

--- a/svd/rp2040.yaml
+++ b/svd/rp2040.yaml
@@ -646,6 +646,9 @@ SPI0:
 
 VREG_AND_CHIP_RESET:
   VREG:
+    _modify:
+      VSEL:
+        description: "Output voltage select for on-chip voltage regulator."
     VSEL:
       _replace_enum:
         Voltage0_85: [6, "0.85V"]

--- a/svd/rp2040.yaml
+++ b/svd/rp2040.yaml
@@ -644,6 +644,21 @@ SPI0:
         Texas_Instruments: [1, "Texas Instruments synchronous serial frame format"]
         National_Semiconductor_Microwire: [2, "National Semiconductor Microwire frame format"]
 
+VREG_AND_CHIP_RESET:
+  VREG:
+    VSEL:
+      _replace_enum:
+        Voltage0_85: [6, "0.85V"]
+        Voltage0_90: [7, "0.90V"]
+        Voltage0_95: [8, "0.95V"]
+        Voltage1_00: [9, "1.00V"]
+        Voltage1_05: [10, "1.05V"]
+        Voltage1_10: [11, "1.10V (default)"]
+        Voltage1_15: [12, "1.15V"]
+        Voltage1_20: [13, "1.20V"]
+        Voltage1_25: [14, "1.25V"]
+        Voltage1_30: [15, "1.30V"]
+
 IO_QSPI:
   _cluster:
     "GPIO_QSPI%s":


### PR DESCRIPTION
The increase in core voltage is mainly used for overclocking.
At first I sent a PR https://github.com/rp-rs/rp-hal/pull/757 to rp-hal, but on @ithinuel's advice I decided to contribute to the PAC first.  

This allows the voltage to be set in this way.  
`pac.VREG_AND_CHIP_RESET.write(|w| w.vsel.variant(VSEL_A::VOLTAGE1_20));`

Previously, unsafe was required :(
`pac.VREG_AND_CHIP_RESET.write(|w| unsafe { w.vsel().bits(12u8) });`