### PR TITLE
Update form to 0.11.1

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -6,7 +6,7 @@ SVDTOOLS="${SVDTOOLS:-svdtools}"
 set -ex
 
 cargo install --version 0.29.0 svd2rust
-cargo install --version 0.10.0  form
+cargo install --version 0.11.1  form
 rustup component add rustfmt
 if [ "$SVDTOOLS" == "svdtools" ]; then
     cargo install --version 0.3.1 svdtools


### PR DESCRIPTION
No changes were found in the generated files.  

New versions of svd2rust and svdtools are also available, but I'm starting with the PR of form, which is the easiest to update.