### PR TITLE
Update github runner image to ubuntu 24.04

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,7 +3,7 @@ name: Build and Test check
 jobs:
   check:
     name: cargo-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: Clippy check
 jobs:
   clippy_check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -3,7 +3,7 @@ name: Code formatting check
 jobs:
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,7 +3,7 @@ name: Run update.sh and check for changed files
 jobs:
   check:
     name: cargo-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - run: ./update.sh


### PR DESCRIPTION
20.04 is no longer supported, see https://github.com/actions/runner-images/issues/11101